### PR TITLE
Update utils to have dependencies consolidated with proper design practice

### DIFF
--- a/ed25519_encode.go
+++ b/ed25519_encode.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/proximax-storage/nem2-sdk-go/utils"
+	"github.com/proximax-storage/go-xpx-utils"
 	"math/big"
 )
 

--- a/key_model.go
+++ b/key_model.go
@@ -7,7 +7,7 @@ package crypto
 import (
 	"encoding/hex"
 	"github.com/pkg/errors"
-	"github.com/proximax-storage/nem2-sdk-go/utils"
+	"github.com/proximax-storage/go-xpx-utils"
 	"math/big"
 	"strings"
 )

--- a/math.go
+++ b/math.go
@@ -8,7 +8,7 @@ import (
 	rand2 "crypto/rand"
 	"encoding/binary"
 	"errors"
-	"github.com/proximax-storage/nem2-sdk-go/utils"
+	"github.com/proximax-storage/go-xpx-utils"
 	"io"
 	"math/big"
 )

--- a/signature.go
+++ b/signature.go
@@ -7,7 +7,7 @@ package crypto
 import (
 	"encoding/hex"
 	"errors"
-	"github.com/proximax-storage/nem2-sdk-go/utils"
+	"github.com/proximax-storage/go-xpx-utils"
 	"math"
 	"math/big"
 )


### PR DESCRIPTION
To move util dependencies from SDK. This will enable proper design practice since Crypto and Utils are part of Core and SDK should depend on them, not the other way around. Issue raised in [Utils](https://github.com/proximax-storage/go-xpx-utils/issues/6)